### PR TITLE
fix: read singular config at the right time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,6 @@ export default (api: IApi) => {
 
   api.addPageWatcher(() => {
     const modelsPath = getModelsPath();
-    console.log('modelsPath', modelsPath);
     return [modelsPath];
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,28 +6,37 @@ import getUserModelContent from './utils/getUserModelContent';
 
 export default (api: IApi) => {
   const { paths, config } = api;
-  const modelsPath = join(paths.absSrcPath, config.singular ? 'model' : 'models');
+
+  function getModelsPath() {
+    return join(paths.absSrcPath, config.singular ? 'model' : 'models');
+  }
 
   // Add provider wrapper with rootContainer
   api.addRuntimePlugin(join(__dirname, './runtime'));
 
   api.onGenerateFiles(() => {
+    const modelsPath = getModelsPath();
     try {
       const additionalModels = api.applyPlugins('addExtraModels', {
         initialValue: [],
       });
       // Write models/provider.tsx
-      api.writeTmpFile(`${DIR_NAME_IN_TMP}/Provider.tsx`, getProviderContent(modelsPath, additionalModels));
+      api.writeTmpFile(
+        `${DIR_NAME_IN_TMP}/Provider.tsx`,
+        getProviderContent(modelsPath, additionalModels),
+      );
       // Write models/useModel.tsx
       api.writeTmpFile(`${DIR_NAME_IN_TMP}/useModel.tsx`, getUserModelContent());
-    } catch(e) {
+    } catch (e) {
       api.log.error(e);
     }
   });
 
-  api.addPageWatcher([
-    modelsPath,
-  ]);
+  api.addPageWatcher(() => {
+    const modelsPath = getModelsPath();
+    console.log('modelsPath', modelsPath);
+    return [modelsPath];
+  });
 
   // Export useModel and Models from umi
   api.addUmiExports([


### PR DESCRIPTION
在 Bigfish 里面 singular 这个配置是在插件初始化之后才挂载的，所以需要在异步回调中去读取，不能在插件初始化的时候就读取。