### PR TITLE
fix: useEffect closure trap

### DIFF
--- a/src/utils/getUseModelContent.ts
+++ b/src/utils/getUseModelContent.ts
@@ -6,6 +6,8 @@ import isEqual from '${require.resolve('lodash.isequal')}';
 import { UmiContext } from '${join(__dirname, '..', 'helpers', 'constant')}';
 import { Model } from './provider';
 
+const USEMODELINIT = Symbol('useModelInit');
+
 export function useModel<T extends keyof Model<T>>(model: T): Model<T>[T]
 export function useModel<T extends keyof Model<T>, U>(model: T, selector: (model: Model<T>[T]) => U): U
 
@@ -22,11 +24,15 @@ export function useModel<T extends keyof Model<T>, U>(
     () => updaterRef.current ? updaterRef.current(dispatcher.data![namespace]) : dispatcher.data![namespace]
   );
 
+  const lastState = useRef<any>(USEMODELINIT);
+
   useEffect(() => {
     const handler = (e: any) => {
       if(updater && updaterRef.current){
         const ret = updaterRef.current(e);
-        if(!isEqual(ret, state)){
+        const realState = lastState.current === USEMODELINIT ? state : lastState.current;
+        if(!isEqual(ret, realState)){
+          lastState.current = ret;
           setState(ret);
         }
       } else {


### PR DESCRIPTION
close #24 

In the example, when the `add ` or ` minus` button is operated to make the `counter` state not be the initial value, and then the intended operation becomes the initial value, the` counter` state can never be changed to the initial value.

在例子中，当操作 `add` 或 `minus` 按钮使 `counter` 状态不为初值后再意图操作变为初值时，`counter` 状态永远无法变为初值。